### PR TITLE
implementing getIsReplaying() method for Authoring API

### DIFF
--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
@@ -95,4 +95,9 @@ public class DaprWorkflowContextImpl implements WorkflowContext {
   public Task<Void> waitForExternalEvent(String eventName, Duration timeout) {
     return this.innerContext.waitForExternalEvent(eventName, timeout);
   }
+
+  @Override
+  public boolean getIsReplaying() {
+    return this.innerContext.getIsReplaying();
+  }
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
@@ -66,4 +66,6 @@ public interface WorkflowContext {
    * @return Asynchronous task to {@code await()}.
    */
   Task waitForExternalEvent(String eventName, Duration timeout);
+
+  boolean getIsReplaying();
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
@@ -67,5 +67,20 @@ public interface WorkflowContext {
    */
   Task waitForExternalEvent(String eventName, Duration timeout);
 
+  /**
+   * Gets a value indicating whether the workflow is currently replaying a previous execution.
+   * <p>
+   * Workflow functions are "replayed" after being unloaded from memory to reconstruct local variable state.
+   * During a replay, previously executed tasks will be completed automatically with previously seen values
+   * that are stored in the workflow history. Once the workflow reaches the point where it's no longer
+   * replaying existing history, this method will return {@code false}.
+   * <p>
+   * You can use this method if you have logic that needs to run only when <em>not</em> replaying. For example,
+   * certain types of application logging may become too noisy when duplicated as part of replay. The
+   * application code could check to see whether the function is being replayed and then issue the log statements
+   * when this value is {@code false}.
+   *
+   * @return {@code true} if the workflow is replaying, otherwise {@code false}
+   */
   boolean getIsReplaying();
 }

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/WorkflowContext.java
@@ -69,13 +69,13 @@ public interface WorkflowContext {
 
   /**
    * Gets a value indicating whether the workflow is currently replaying a previous execution.
-   * <p>
-   * Workflow functions are "replayed" after being unloaded from memory to reconstruct local variable state.
+   *
+   * <p>Workflow functions are "replayed" after being unloaded from memory to reconstruct local variable state.
    * During a replay, previously executed tasks will be completed automatically with previously seen values
    * that are stored in the workflow history. Once the workflow reaches the point where it's no longer
    * replaying existing history, this method will return {@code false}.
-   * <p>
-   * You can use this method if you have logic that needs to run only when <em>not</em> replaying. For example,
+   *
+   * <p>You can use this method if you have logic that needs to run only when <em>not</em> replaying. For example,
    * certain types of application logging may become too noisy when duplicated as part of replay. The
    * application code could check to see whether the function is being replayed and then issue the log statements
    * when this value is {@code false}.

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
@@ -66,9 +66,15 @@ public class DaprWorkflowContextImplTest {
   }
 
   @Test
+  public void getIsReplaying() {
+    context.getIsReplaying();
+    verify(mockInnerContext, times(1)).getIsReplaying();
+  }
+
+  @Test
   public void getLoggerReplayingTest() {
     Logger mockLogger = mock(Logger.class);
-    when(mockInnerContext.getIsReplaying()).thenReturn(true);
+    when(context.getIsReplaying()).thenReturn(true);
     DaprWorkflowContextImpl testContext = new DaprWorkflowContextImpl(mockInnerContext, mockLogger);
 
     String expectedArg = "test print";
@@ -80,7 +86,7 @@ public class DaprWorkflowContextImplTest {
   @Test
   public void getLoggerFirstTimeTest() {
     Logger mockLogger = mock(Logger.class);
-    when(mockInnerContext.getIsReplaying()).thenReturn(false);
+    when(context.getIsReplaying()).thenReturn(false);
     DaprWorkflowContextImpl testContext = new DaprWorkflowContextImpl(mockInnerContext, mockLogger);
 
     String expectedArg = "test print";


### PR DESCRIPTION
# Description

Exposing getIsReplaying( ) method for Workflow Authoring API.
Tests that were using DurableTask SDK are now calling from Workflow's

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[TASK 46756](https://dev.azure.com/CSECodeHub/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud/_workitems/edit/46756)_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
