### PR TITLE
fixing issue with getIsReplaying() call

### DIFF
--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
@@ -98,7 +98,7 @@ public class DaprWorkflowContextImplTest {
   @Test
   public void getLoggerReplayingTest() {
     Logger mockLogger = mock(Logger.class);
-    when(context.getIsReplaying()).thenReturn(true);
+    when(mockInnerContext.getIsReplaying()).thenReturn(true);
     DaprWorkflowContextImpl testContext = new DaprWorkflowContextImpl(mockInnerContext, mockLogger);
 
     String expectedArg = "test print";
@@ -110,7 +110,7 @@ public class DaprWorkflowContextImplTest {
   @Test
   public void getLoggerFirstTimeTest() {
     Logger mockLogger = mock(Logger.class);
-    when(context.getIsReplaying()).thenReturn(false);
+    when(mockInnerContext.getIsReplaying()).thenReturn(false);
     DaprWorkflowContextImpl testContext = new DaprWorkflowContextImpl(mockInnerContext, mockLogger);
 
     String expectedArg = "test print";


### PR DESCRIPTION
Fixing issues for `getIsReplaying` method calls in `getLoggerReplayingTest()` and `getLoggerFirstTimeTest()` methods.

the test should refer to the `mockInnerContext` from DurableTask and not the workflow object.