### PR TITLE
Send Event Implementation

### DIFF
--- a/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflow.java
+++ b/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflow.java
@@ -28,10 +28,18 @@ public class DemoWorkflow extends Workflow {
     ctx.getLogger().info("Starting Workflow: " + ctx.getName());
     ctx.getLogger().info("Instance ID: " + ctx.getInstanceId());
     ctx.getLogger().info("Current Orchestration Time: " + ctx.getCurrentInstant());
-    ctx.getLogger().info("Waiting for event: 'myEvent'...");
+    ctx.getLogger().info("Waiting for event: 'TimedOutEvent'...");
     try {
-      ctx.waitForExternalEvent("myEvent", Duration.ofSeconds(10)).await();
-      ctx.getLogger().info("Received!");
+      ctx.waitForExternalEvent("TimedOutEvent", Duration.ofSeconds(10)).await();
+    } catch (TaskCanceledException e) {
+      ctx.getLogger().warn("Timed out");
+      ctx.getLogger().warn(e.getMessage());
+    }
+
+    ctx.getLogger().info("Waiting for event: 'TestEvent'...");
+    try {
+      ctx.waitForExternalEvent("TestEvent", Duration.ofSeconds(10)).await();
+      ctx.getLogger().info("Received TestEvent");
     } catch (TaskCanceledException e) {
       ctx.getLogger().warn("Timed out");
       ctx.getLogger().warn(e.getMessage());

--- a/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
+++ b/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
@@ -13,7 +13,6 @@ limitations under the License.
 
 package io.dapr.examples.workflows;
 
-import com.microsoft.durabletask.OrchestrationRuntimeStatus;
 import io.dapr.workflows.client.DaprWorkflowClient;
 import io.dapr.workflows.client.WorkflowState;
 
@@ -28,7 +27,7 @@ public class DemoWorkflowClient {
 
   /**
    * The main method.
-   * 
+   *
    * @param args Input arguments (unused).
    * @throws InterruptedException If program has been interrupted.
    */
@@ -49,7 +48,7 @@ public class DemoWorkflowClient {
       System.out.println(separatorStr);
       System.out.println("**WaitForInstanceStart**");
       try {
-        WorkflowState waitForInstanceStartResult = 
+        WorkflowState waitForInstanceStartResult =
             client.waitForInstanceStart(instanceId, Duration.ofSeconds(60), true);
         System.out.printf("Result: %s%n", waitForInstanceStartResult);
       } catch (TimeoutException ex) {
@@ -57,9 +56,13 @@ public class DemoWorkflowClient {
       }
 
       System.out.println(separatorStr);
+      System.out.println("**SendExternalMessage**");
+      client.raiseEvent(instanceId, "TestEvent", "TestEventPayload");
+
+      System.out.println(separatorStr);
       System.out.println("**WaitForInstanceCompletion**");
       try {
-        WorkflowState waitForInstanceCompletionResult = 
+        WorkflowState waitForInstanceCompletionResult =
             client.waitForInstanceCompletion(instanceId, Duration.ofSeconds(60), true);
         System.out.printf("Result: %s%n", waitForInstanceCompletionResult);
       } catch (TimeoutException ex) {
@@ -69,7 +72,7 @@ public class DemoWorkflowClient {
       System.out.println(separatorStr);
       System.out.println("**purgeInstance**");
       boolean purgeResult = client.purgeInstance(instanceId);
-      System.out.printf("purgeResult: %s%n",purgeResult);
+      System.out.printf("purgeResult: %s%n", purgeResult);
 
       System.out.println(separatorStr);
       System.out.println("**raiseEvent**");

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
@@ -14,6 +14,7 @@ limitations under the License.
 package io.dapr.workflows.runtime;
 
 import com.microsoft.durabletask.Task;
+import com.microsoft.durabletask.TaskCanceledException;
 import com.microsoft.durabletask.TaskOptions;
 import com.microsoft.durabletask.TaskOrchestrationContext;
 import org.slf4j.Logger;
@@ -102,15 +103,17 @@ public class DaprWorkflowContextImpl implements WorkflowContext {
   /**
    * {@inheritDoc}
    */
-  public Task<Void> waitForExternalEvent(String eventName, Duration timeout) {
-    return this.innerContext.waitForExternalEvent(eventName, timeout);
+  @Override
+  public <V> Task<V> waitForExternalEvent(String name, Duration timeout, Class<V> dataType)
+      throws TaskCanceledException {
+    return this.innerContext.waitForExternalEvent(name, timeout, dataType);
   }
-  
+
   @Override
   public boolean getIsReplaying() {
     return this.innerContext.getIsReplaying();
   }
-  
+
   /**
    * {@inheritDoc}
    */

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
@@ -60,7 +60,7 @@ public class DaprWorkflowContextImplTest {
     Duration expectedDuration = Duration.ofSeconds(1);
 
     context.waitForExternalEvent(expectedEvent, expectedDuration);
-    verify(mockInnerContext, times(1)).waitForExternalEvent(expectedEvent, expectedDuration);
+    verify(mockInnerContext, times(1)).waitForExternalEvent(expectedEvent, expectedDuration, Void.class);
   }
 
   @Test


### PR DESCRIPTION
# Description

I have added a method call to demo for raising events.
Also, `waitForExternalEvents` was missing the correct method signature.

Note: `sendEvent` method is not supported by DurableTask framework 😅 
I'm not going to implement that and I have closed that task.

https://github.com/microsoft/durabletask-java/blob/293489f269972678ba0e1bc1ee4cfabd7b8ec5b5/client/src/main/java/com/microsoft/durabletask/TaskOrchestrationExecutor.java#L825

Implementing this method in our SDK throws following exception:


```bash
WARN[0015] don't know how to process outbound message %v{eventId:2 timestamp:{seconds:1686827051 nanos:56574000} eventSent:{instanceId:"cca66fd6-3033-4c8f-a533-f061d745f827" name:"myEvent"} cca66fd6-3033-4c8f-a533-f061d745f827}  app_id=demoworkflowworker instance=MSFT-Macbook scope=dapr.runtime.wfengine type=log ver=1.11.0


== APP == WARNING: The orchestrator failed with an unhandled exception: java.lang.IllegalStateException: Don't know how to hand

```

## Issue reference

https://dev.azure.com/CSECodeHub/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud/_sprints/taskboard/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud%20Team/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud/Sharing%20Sprint%201?workitem=46609

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
