### PR TITLE
Implementing allOf, anyOf, createTimer methods

### DIFF
--- a/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflow.java
+++ b/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflow.java
@@ -13,11 +13,15 @@ limitations under the License.
 
 package io.dapr.examples.workflows;
 
+import com.microsoft.durabletask.CompositeTaskFailedException;
+import com.microsoft.durabletask.Task;
 import com.microsoft.durabletask.TaskCanceledException;
 import io.dapr.workflows.runtime.Workflow;
 import io.dapr.workflows.runtime.WorkflowContext;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implementation of the DemoWorkflow for the server side.
@@ -45,6 +49,40 @@ public class DemoWorkflow extends Workflow {
       ctx.getLogger().warn(e.getMessage());
     }
 
+    ctx.getLogger().info("Parallel Execution - Waiting for all tasks to finish...");
+    try {
+      Task<String> t1 = ctx.waitForExternalEvent("event1", Duration.ofSeconds(5), String.class);
+      Task<String> t2 = ctx.waitForExternalEvent("event2", Duration.ofSeconds(5), String.class);
+      Task<String> t3 = ctx.waitForExternalEvent("event3", Duration.ofSeconds(5), String.class);
+
+      List<String> results = ctx.allOf(Arrays.asList(t1, t2, t3)).await();
+      results.forEach(t -> ctx.getLogger().info("finished task: " + t));
+      ctx.getLogger().info("All tasks finished!");
+
+    } catch (CompositeTaskFailedException e) {
+      ctx.getLogger().warn(e.getMessage());
+      List<Exception> exceptions = e.getExceptions();
+      exceptions.forEach(ex -> ctx.getLogger().warn(ex.getMessage()));
+    }
+
+    ctx.getLogger().info("Parallel Execution - Waiting for any task to finish...");
+    try {
+      Task<String> e1 = ctx.waitForExternalEvent("e1", Duration.ofSeconds(5), String.class);
+      Task<String> e2 = ctx.waitForExternalEvent("e2", Duration.ofSeconds(5), String.class);
+      Task<String> e3 = ctx.waitForExternalEvent("e3", Duration.ofSeconds(5), String.class);
+      Task<Void> timeoutTask = ctx.createTimer(Duration.ofSeconds(1));
+
+      Task<?> winner = ctx.anyOf(Arrays.asList(e1, e2, e3, timeoutTask)).await();
+      if (winner == timeoutTask) {
+        ctx.getLogger().info("All tasks timed out!");
+      } else {
+        ctx.getLogger().info("One of the tasks finished!");
+      }
+    } catch (TaskCanceledException e) {
+      ctx.getLogger().warn("Timed out");
+      ctx.getLogger().warn(e.getMessage());
+    }
+
     ctx.getLogger().info("Calling Activity...");
     var input = new DemoActivityInput("Hello Activity!");
     var output = ctx.callActivity(DemoWorkflowActivity.class.getName(), input, DemoActivityOutput.class).await();
@@ -52,7 +90,6 @@ public class DemoWorkflow extends Workflow {
     ctx.getLogger().info("Activity returned: " + output);
     ctx.getLogger().info("Activity returned: " + output.getNewMessage());
     ctx.getLogger().info("Activity returned: " + output.getOriginalMessage());
-
 
     ctx.getLogger().info("Workflow finished");
     ctx.complete("finished");

--- a/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
+++ b/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
@@ -60,7 +60,7 @@ public class DemoWorkflowClient {
       client.raiseEvent(instanceId, "TestEvent", "TestEventPayload");
 
       System.out.println(separatorStr);
-      System.out.println("** Registering parallel Events to be captured by allOf(t1,t2,t3**");
+      System.out.println("** Registering parallel Events to be captured by allOf(t1,t2,t3) **");
       client.raiseEvent(instanceId, "event1", "TestEvent 1 Payload");
       client.raiseEvent(instanceId, "event2", "TestEvent 2 Payload");
       client.raiseEvent(instanceId, "event3", "TestEvent 3 Payload");

--- a/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
+++ b/examples/src/main/java/io/dapr/examples/workflows/DemoWorkflowClient.java
@@ -60,6 +60,19 @@ public class DemoWorkflowClient {
       client.raiseEvent(instanceId, "TestEvent", "TestEventPayload");
 
       System.out.println(separatorStr);
+      System.out.println("** Registering parallel Events to be captured by allOf(t1,t2,t3**");
+      client.raiseEvent(instanceId, "event1", "TestEvent 1 Payload");
+      client.raiseEvent(instanceId, "event2", "TestEvent 2 Payload");
+      client.raiseEvent(instanceId, "event3", "TestEvent 3 Payload");
+      System.out.printf("Events raised for workflow with instanceId: %s\n", instanceId);
+
+      System.out.println(separatorStr);
+      System.out.println("** Registering Event to be captured by anyOf(t1,t2,t3) **");
+      client.raiseEvent(instanceId, "e2", "event 2 Payload");
+      System.out.printf("Event raised for workflow with instanceId: %s\n", instanceId);
+
+
+      System.out.println(separatorStr);
       System.out.println("**WaitForInstanceCompletion**");
       try {
         WorkflowState waitForInstanceCompletionResult =

--- a/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
+++ b/sdk-workflows/src/main/java/io/dapr/workflows/runtime/DaprWorkflowContextImpl.java
@@ -13,6 +13,7 @@ limitations under the License.
 
 package io.dapr.workflows.runtime;
 
+import com.microsoft.durabletask.CompositeTaskFailedException;
 import com.microsoft.durabletask.Task;
 import com.microsoft.durabletask.TaskCanceledException;
 import com.microsoft.durabletask.TaskOptions;
@@ -23,6 +24,7 @@ import org.slf4j.helpers.NOPLogger;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 
 /**
  * Dapr workflow context implementation.
@@ -119,5 +121,26 @@ public class DaprWorkflowContextImpl implements WorkflowContext {
    */
   public <V> Task<V> callActivity(String name, Object input, TaskOptions options, Class<V> returnType) {
     return this.innerContext.callActivity(name, input, options, returnType);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public <V> Task<List<V>> allOf(List<Task<V>> tasks) throws CompositeTaskFailedException {
+    return this.innerContext.allOf(tasks);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public Task<Task<?>> anyOf(List<Task<?>> tasks) {
+    return this.innerContext.anyOf(tasks);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public Task<Void> createTimer(Duration duration) {
+    return this.innerContext.createTimer(duration);
   }
 }

--- a/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
+++ b/sdk-workflows/src/test/java/io/dapr/workflows/runtime/DaprWorkflowContextImplTest.java
@@ -13,12 +13,15 @@ limitations under the License.
 
 package io.dapr.workflows.runtime;
 
+import com.microsoft.durabletask.Task;
 import com.microsoft.durabletask.TaskOrchestrationContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -90,7 +93,7 @@ public class DaprWorkflowContextImplTest {
   }
 
   @Test
-  public void getIsReplaying() {
+  public void getIsReplayingTest() {
     context.getIsReplaying();
     verify(mockInnerContext, times(1)).getIsReplaying();
   }
@@ -117,5 +120,34 @@ public class DaprWorkflowContextImplTest {
     testContext.getLogger().info(expectedArg);
 
     verify(mockLogger, times(1)).info(expectedArg);
+  }
+
+  @Test
+  public void allOfTest() {
+    Task<Void> t1 = mockInnerContext.callActivity("task1");
+    Task<Void> t2 = mockInnerContext.callActivity("task2");
+    List<Task<Void>> taskList = Arrays.asList(t1, t2);
+    context.allOf(taskList);
+    verify(mockInnerContext, times(1)).allOf(taskList);
+  }
+
+  @Test
+  public void anyOfTest() {
+    Task<Void> t1 = mockInnerContext.callActivity("task1");
+    Task<Void> t2 = mockInnerContext.callActivity("task2");
+    Task<Void> t3 = mockInnerContext.callActivity("task3");
+    List<Task<?>> taskList = Arrays.asList(t1, t2);
+
+    context.anyOf(taskList);
+    verify(mockInnerContext, times(1)).anyOf(taskList);
+
+    context.anyOf(t1, t2, t3);
+    verify(mockInnerContext, times(1)).anyOf(Arrays.asList(t1, t2, t3));
+  }
+
+  @Test
+  public void createTimerTest() {
+    context.createTimer(Duration.ofSeconds(10));
+    verify(mockInnerContext, times(1)).createTimer(Duration.ofSeconds(10));
   }
 }


### PR DESCRIPTION
# Description

Implementation of the following methods
- `allOf(List<Task>)`
- `anyOf(List<Task>)`
- `anyOf(Array<Task>)`
- `createTimer(Duration)`

`createTimer(ZonedDateTime)` is not implemented in DurableTask API

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: 
[TASK 46603](https://dev.azure.com/CSECodeHub/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud/_workitems/edit/46603)
[TASK 46605](https://dev.azure.com/CSECodeHub/555239%20-%20B3%20NoMe%20Transition%20to%20the%20Cloud/_workitems/edit/46605)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
